### PR TITLE
change the was server name is determined for CAS call so that it will work with mod_proxy

### DIFF
--- a/src/main/java/edu/yale/sml/servlet/CasNetIdFilter.java
+++ b/src/main/java/edu/yale/sml/servlet/CasNetIdFilter.java
@@ -21,6 +21,8 @@ import edu.yale.sml.logic.LogicHelper;
 public class CasNetIdFilter implements Filter {
 
     private static final Logger logger = LoggerFactory.getLogger(CasNetIdFilter.class);
+    private String serverName;
+
 
     public CasNetIdFilter() {
         super();
@@ -28,19 +30,22 @@ public class CasNetIdFilter implements Filter {
 
     public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain) throws IOException, ServletException {
         HttpServletRequest request = (HttpServletRequest) req;
-        final String var = "http://" + request.getServerName() + ":"
-                + request.getServerPort() + request.getContextPath() + "/pages/index.xhtml";
+        final String var = serverName + request.getContextPath() + "/pages/index.xhtml";
         final String ticket = req.getParameter("ticket");
 
         if (ticket == null || ticket.isEmpty()) {
             throw new ServletException("Failure to log in");
         }
-
+        logger.debug("Sending " + var );
         final String service = URLEncoder.encode(var);
         final String param = "ticket=" + ticket + "&service=" + service;
 
         try {
             final List<String> userList = LogicHelper.getCASUser(Constants.CAS_VALIDATE_URL, new StringBuffer(param));
+            if ( userList.size() < 3 ) {
+		throw new IOException ("Error with User List from CAS: [" + userList.get(0) + ","+userList.get(1)+"]   " + var + "  " + param);
+            }
+            logger.debug("Received from cas: {}", userList.size());
             final String user = userList.get(2).trim();
             request.getSession().setAttribute(Constants.NETID, user);
             logger.trace("Saved user in session={}", user);
@@ -57,6 +62,7 @@ public class CasNetIdFilter implements Filter {
     public void destroy() {
     }
 
-    public void init(FilterConfig arg0) throws ServletException {
+    public void init(FilterConfig filterConfig) throws ServletException {
+       serverName = filterConfig.getInitParameter("serverName");
     }
 }


### PR DESCRIPTION
This change is necessary so that the server name used to make the CAS call can be configured in web.xml so that it will work when tomcat is behind Apache with mod_proxy.