### PR TITLE
Update pom file and change cas validate to use GET for compatibility with new CAS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,11 @@
     <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>Shelf Scan Application</description>
-
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>1.8</java.version>
+    </properties>
     <dependencies>
         <dependency>
             <groupId>commons-io</groupId>
@@ -167,10 +171,11 @@
             <artifactId>janino</artifactId>
             <version>2.5.16</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.oracle.database.jdbc/ojdbc8 -->
         <dependency>
-            <groupId>oracle</groupId>
-            <artifactId>ojdbc6</artifactId>
-            <version>11.2.0.3</version>
+            <groupId>com.oracle.database.jdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>19.7.0.0</version>
         </dependency>
         <dependency>
             <groupId>javax.jms</groupId>
@@ -182,22 +187,31 @@
             <artifactId>activemq-core</artifactId>
             <version>5.2.0</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.microsoft.sqlserver/mssql-jdbc -->
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>sqljdbc4</artifactId>
-            <version>4.0</version>
-            <scope>runtime</scope>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>8.4.1.jre11</version>
         </dependency>
         <dependency>
             <groupId>com.thoughtworks.xstream</groupId>
             <artifactId>xstream</artifactId>
             <version>1.4.5</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.projectlombok/lombok -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.14.2</version>
+            <version>1.18.12</version>
+            <scope>provided</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+
     </dependencies>
 
     <repositories>

--- a/src/main/java/edu/yale/sml/logic/LogicHelper.java
+++ b/src/main/java/edu/yale/sml/logic/LogicHelper.java
@@ -236,12 +236,9 @@ public class LogicHelper {
         List<String> response = new ArrayList<String>();
         StringBuffer response_body = new StringBuffer();
         try {
-            URL url = new URL(cas_server_url);
+            URL url = new URL(cas_server_url + "?" + contents.toString());
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
-            conn.setDoOutput(true);
-            writer = new OutputStreamWriter(conn.getOutputStream());
-            writer.write(contents.toString());
-            writer.flush();
+            conn.setRequestMethod("GET");
             in = new BufferedReader(new InputStreamReader(conn.getInputStream()));
             response.add(new String(Integer.toString(conn.getResponseCode())));
             String decodedString = "";
@@ -254,7 +251,7 @@ public class LogicHelper {
         } catch (java.net.UnknownHostException e) {
             throw new java.net.UnknownHostException();
         } catch (IOException e) {
-            throw new IOException(e);
+            throw new IOException(contents.toString(), e);
         } finally {
             try {
                 if (writer != null) {


### PR DESCRIPTION
Update pom file to work with newer versions of Java and more recent (and available) packages on Maven Central.

Changes CAS call to /validate/ with GET rather than POST.  The new version of CAS does not accept POST.  Both versions accept GET, so this change is backward and forward compatible.